### PR TITLE
Update SRMC_crix.r

### DIFF
--- a/SRMC_crix/SRMC_crix.r
+++ b/SRMC_crix/SRMC_crix.r
@@ -17,7 +17,7 @@ library("rjson")
 library(fGarch)
 
 # Get the daily log return of crix price 
-crix      = fromJSON("SRMC_crix.json")
+crix=read.csv(file = 'SRMC_crix') 
 price.log.return  = diff(log(crix$price))
 price.log.return  = na.omit(price.log.return)
 


### PR DESCRIPTION
the datafile SRMC_crix.json is problematic, as the code “crix=read.csv(file = 'SRMC_crix')” gives an error: "Error in fromJSON("SRMC_crix.json") : not all data was parsed (0 chars were parsed out of a total of 14 chars)". SO better use the alternative datafile "SRMC_crix" with "crix=read.csv(file = 'SRMC_crix')"